### PR TITLE
Fixed buy ticket functionality

### DIFF
--- a/src/main/java/at/fhv/td/communication/dto/TicketRequestDTO.java
+++ b/src/main/java/at/fhv/td/communication/dto/TicketRequestDTO.java
@@ -1,27 +1,25 @@
 package at.fhv.td.communication.dto;
 
-import at.fhv.td.communication.rmi.interfaces.ITicketDTO;
-
 import java.io.Serializable;
 import java.util.Map;
 
 public class TicketRequestDTO implements Serializable {
-    private ITicketDTO _ticketDto;
-    private Map<Long, Integer[]> _seatPlaceReservations;
+    private TicketDTO _ticketDto;
+    private Map<String, Integer[]> _seatPlaceReservations;
 
-    public ITicketDTO getTicketDto() {
+    public TicketDTO getTicketDto() {
         return _ticketDto;
     }
 
-    public void setTicketDto(ITicketDTO ticketDto) {
+    public void setTicketDto(TicketDTO ticketDto) {
         _ticketDto = ticketDto;
     }
 
-    public Map<Long, Integer[]> getSeatPlaceReservations() {
+    public Map<String, Integer[]> getSeatPlaceReservations() {
         return _seatPlaceReservations;
     }
 
-    public void setSeatPlaceReservations(Map<Long, Integer[]> seatPlaceReservations) {
+    public void setSeatPlaceReservations(Map<String, Integer[]> seatPlaceReservations) {
         _seatPlaceReservations = seatPlaceReservations;
     }
 }

--- a/src/main/java/at/fhv/td/communication/rest/BuyTicketRest.java
+++ b/src/main/java/at/fhv/td/communication/rest/BuyTicketRest.java
@@ -13,22 +13,32 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
 @Path("/buyTicket")
-@Produces(MediaType.APPLICATION_JSON)
-@Consumes(MediaType.APPLICATION_JSON)
 public class BuyTicketRest {
     @POST
+    @Produces(MediaType.APPLICATION_JSON)
+    @Consumes(MediaType.APPLICATION_JSON)
     public Response buyTicket(TicketRequestDTO ticketRequest) {
         if (ticketRequest != null) {
             try {
+                System.out.println(ticketRequest.getTicketDto().getCategoryName());
+                System.out.println(ticketRequest.getSeatPlaceReservations().get("1").length);
+                System.out.println(ticketRequest.getSeatPlaceReservations().get("1")[0]);
 
                 Ticket basicTicket = TicketAssembler.toTicket(ticketRequest.getTicketDto());
-                TicketAnswer answer = (TicketController.buyTicket(basicTicket, ticketRequest.getSeatPlaceReservations()));
+                Map<Long, Integer[]> ticketsToBuy = new HashMap<>();
+                for (Map.Entry<String, Integer[]> entry : ticketRequest.getSeatPlaceReservations().entrySet()) {
+                    ticketsToBuy.put(new Long(entry.getKey()), entry.getValue());
+                }
+                TicketAnswer answer = (TicketController.buyTicket(basicTicket, ticketsToBuy));
                 AtomicInteger ticketAmount = new AtomicInteger();
                 ticketRequest.getSeatPlaceReservations().forEach((cat, seats) -> ticketAmount.addAndGet(seats.length));
 
+                System.out.println(answer.getTickets().size() + " - " + ticketAmount.get());
                 if (answer.getTickets().size() == ticketAmount.get()) {
                     ITicketDTO[] tickets = answer.getTickets().stream().map(TicketAssembler::toTicketDTO).toArray(ITicketDTO[]::new);
                     return Response.status(200).header("Access-Control-Allow-Origin", "*").entity(tickets).build();

--- a/src/test/java/at/fhv/td/communication/dto/TicketRequestDTOTest.java
+++ b/src/test/java/at/fhv/td/communication/dto/TicketRequestDTOTest.java
@@ -6,18 +6,15 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import java.rmi.RemoteException;
 import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.mockito.Mockito.when;
 
 @RunWith(PowerMockRunner.class)
 public class TicketRequestDTOTest {
     private TicketRequestDTO _testTicketRequestDTO;
-    private Map<Long, Integer[]> _seatPlaceReservations;
+    private Map<String, Integer[]> _seatPlaceReservations;
 
     @Mock
     private TicketDTO _testTicketDTO;
@@ -25,7 +22,7 @@ public class TicketRequestDTOTest {
     @Before
     public void before() {
         _seatPlaceReservations = new HashMap<>();
-        _seatPlaceReservations.put(1L, new Integer[]{1, 2});
+        _seatPlaceReservations.put("1", new Integer[]{1, 2});
         _testTicketRequestDTO = new TicketRequestDTO();
     }
 
@@ -36,7 +33,7 @@ public class TicketRequestDTOTest {
     }
 
     @Test
-    public void getAndSetTicketDTO(){
+    public void getAndSetTicketDTO() {
         _testTicketRequestDTO.setTicketDto(_testTicketDTO);
         assertEquals(_testTicketDTO, _testTicketRequestDTO.getTicketDto());
     }


### PR DESCRIPTION
Works now with the following example payload:

```
{
	"ticketDto": {
		"categoryId": 1,
		"categoryName": "Sitzplatzkategorie A",
		"clientId": 1,
		"eventId": 1,
		"id": 1,
		"price": 12.5,
		"sold": 0,
		"ticketNumber": 100
	},
	"seatPlaceReservations": {
		"123456": [28]
	}
}
```