### PR TITLE
ip address fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ and running the following commands inside the payara5 directory:
 # Start the server
 ./bin/asadmin start-domain
 
+# Set the system environment variable "CultureTicketsRmiIP" to whatever IP (or localhost) the RMI should use. Default is 10.0.51.93
 # Deploy the .war file
 ./bin/asadmin deploy path-to-war/itb5-culture-tickets-backend-1.0-SNAPSHOT.war
 
@@ -64,7 +65,7 @@ and running the following commands inside the payara5 directory:
 ```
 
 You can access the payara admin console on `http://localhost:4848/`.
-You can access the app app on `http://localhost:8080/itb5-culture-tickets-backend-1.0-SNAPSHOT/`.
+You can access the app on `http://localhost:8080/itb5-culture-tickets-backend-1.0-SNAPSHOT/`.
 
 ## RESTful Test Client
 You can access the Python Script

--- a/itb5-culture-tickets-backend/src/main/java/at/fhv/td/communication/rmi/SetupRMI.java
+++ b/itb5-culture-tickets-backend/src/main/java/at/fhv/td/communication/rmi/SetupRMI.java
@@ -1,7 +1,5 @@
 package at.fhv.td.communication.rmi;
 
-import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.rmi.RemoteException;
 import java.rmi.registry.LocateRegistry;
 import java.rmi.registry.Registry;
@@ -11,18 +9,17 @@ import java.rmi.registry.Registry;
  */
 public class SetupRMI {
     private static final int PORT = 25565;
-    private static String IP_ADDRESS;
-
-    private SetupRMI() {
-    }
+    private static String IP_ADDRESS = "10.0.51.93";
 
     static {
-        try {
-            String host = InetAddress.getLocalHost().toString();
-            IP_ADDRESS = host.split("/")[1];
-        } catch (UnknownHostException e) {
-            e.printStackTrace();
+        String ipAddress = System.getenv("CultureTicketsRmiIP");
+
+        if(ipAddress != null && !ipAddress.equals("")){
+            IP_ADDRESS = ipAddress;
         }
+    }
+
+    private SetupRMI() {
     }
 
     public static void setupRmiRegistry() {


### PR DESCRIPTION
Added fix:
Get IP address from environment variable "CultureTicketsRmiIP", if not set the standard server ip (10.0.51.93) will be used